### PR TITLE
Update save_prediction in nifti interface to open with the software application

### DIFF
--- a/miscnn/data_loading/interfaces/nifti_io.py
+++ b/miscnn/data_loading/interfaces/nifti_io.py
@@ -167,7 +167,10 @@ class NIFTI_interface(Abstract_IO):
         # Cast pred.dtype to numpy.uint16
         pred = pred.astype(np.uint16)
         # Convert numpy array to NIFTI with spacing
-        nifti = nib.Nifti1Image(pred, affine=self.cache[index])
+        if index in self.cache:
+            nifti = nib.Nifti1Image(pred, affine=self.cache[index])
+        else:
+            nifti = nib.Nifti1Image(pred, affine=None)
         # Delete cached spacing
         del self.cache[index]
         #nifti.get_data_dtype() == pred.dtype

--- a/miscnn/data_loading/interfaces/nifti_io.py
+++ b/miscnn/data_loading/interfaces/nifti_io.py
@@ -151,8 +151,6 @@ class NIFTI_interface(Abstract_IO):
             warnings.warn("Affinity matrix of NIfTI volume can not be parsed.")
         # Calculate absolute values for voxel spacing
         spacing = np.absolute(spacing)
-        # Delete cached spacing
-        del self.cache[i]
         # Return detail dictionary
         return {"spacing":spacing}
 
@@ -166,8 +164,12 @@ class NIFTI_interface(Abstract_IO):
             raise IOError(
                 "Data path, {}, could not be resolved".format(output_path)
             )
-        # Convert numpy array to NIFTI
-        nifti = nib.Nifti1Image(pred, None)
+        # Cast pred.dtype to numpy.uint16
+        pred = pred.astype(np.uint16)
+        # Convert numpy array to NIFTI with spacing
+        nifti = nib.Nifti1Image(pred, affine=self.cache[index])
+        # Delete cached spacing
+        del self.cache[index]
         #nifti.get_data_dtype() == pred.dtype
         # Save segmentation to disk
         pred_file = str(index) + ".nii.gz"

--- a/miscnn/data_loading/interfaces/nifti_io.py
+++ b/miscnn/data_loading/interfaces/nifti_io.py
@@ -169,10 +169,10 @@ class NIFTI_interface(Abstract_IO):
         # Convert numpy array to NIFTI with spacing
         if index in self.cache:
             nifti = nib.Nifti1Image(pred, affine=self.cache[index])
+            # Delete cached spacing
+            del self.cache[index]
         else:
             nifti = nib.Nifti1Image(pred, affine=None)
-        # Delete cached spacing
-        del self.cache[index]
         #nifti.get_data_dtype() == pred.dtype
         # Save segmentation to disk
         pred_file = str(index) + ".nii.gz"


### PR DESCRIPTION
With the issue #64, the software applications such as 3D Slicer or ITK-SNAP can't read the prediction data in this repo.
Including KiTS19, actually, the type of NIFTI format target data consists of type of <class 'numpy.uint16'>.
So, we need to cast the pred in save_prediction function of nifti_io.py as np.uint16.
And also, Affine matrix for spacing is necessary, too.
Therefore, I update the code of the function.

Cheers,
Jim
