### PR TITLE
Resolving grayscale image handling & conversions

### DIFF
--- a/miscnn/data_loading/interfaces/image_io.py
+++ b/miscnn/data_loading/interfaces/image_io.py
@@ -95,8 +95,8 @@ class Image_interface(Abstract_IO):
         # Load image from file
         img_raw = Image.open(os.path.join(img_path, "imaging" + "." + \
                                           self.img_format))
-        # Convert image to rgb or grayscale
-        if self.img_type == "grayscale" and img_raw.mode != "L":
+        # Convert image to rgb or grayscale if needed
+        if self.img_type == "grayscale" and len(img_raw.getbands()) > 1:
             img_pil = img_raw.convert("LA")
         elif self.img_type == "rgb" and img_raw.mode != "RGB":
             img_pil = img_raw.convert("RGB")
@@ -104,7 +104,7 @@ class Image_interface(Abstract_IO):
             img_pil = img_raw
         # Convert Pillow image to numpy matrix
         img = np.array(img_pil)
-        # Keep only intensity for grayscale images
+        # Keep only intensity for grayscale images if needed
         if self.img_type == "grayscale" and len(img.shape) > 2:
             img = img[:, :, 0]
         # Return image

--- a/miscnn/data_loading/interfaces/image_io.py
+++ b/miscnn/data_loading/interfaces/image_io.py
@@ -96,14 +96,17 @@ class Image_interface(Abstract_IO):
         img_raw = Image.open(os.path.join(img_path, "imaging" + "." + \
                                           self.img_format))
         # Convert image to rgb or grayscale
-        if self.img_type == "grayscale":
+        if self.img_type == "grayscale" and img_raw.mode != "L":
             img_pil = img_raw.convert("LA")
-        elif self.img_type == "rgb":
+        elif self.img_type == "rgb" and img_raw.mode != "RGB":
             img_pil = img_raw.convert("RGB")
+        else:
+            img_pil = img_raw
         # Convert Pillow image to numpy matrix
         img = np.array(img_pil)
         # Keep only intensity for grayscale images
-        if self.img_type =="grayscale" : img = img[:,:,0]
+        if self.img_type == "grayscale" and len(img.shape) > 2:
+            img = img[:, :, 0]
         # Return image
         return img, {"type": "image"}
 

--- a/tests/test_iointerfaces.py
+++ b/tests/test_iointerfaces.py
@@ -90,15 +90,15 @@ class IO_interfacesTEST(unittest.TestCase):
     # Loading Images and Segmentations
     def test_IOI_IMAGE_loading(self):
         interface = Image_interface(pattern="image_\\d+")
-        sample_list = interface.initialize(self.tmp_data.name)
+        sample_list = sorted(interface.initialize(self.tmp_data.name))
         img_01 = interface.load_image(sample_list[0])
         seg_01 = interface.load_segmentation(sample_list[0])
-        true_img_01 = np.array(Image.fromarray(self.img[:, :, :3]).convert('LA'))
-        self.assertTrue(np.array_equal(img_01[0], true_img_01[:,:,0]))
+        self.assertTrue(np.array_equal(img_01[0], self.img[:, :, 0]))
         self.assertTrue(np.array_equal(seg_01, self.seg[:,:,0]))
         img_02 = interface.load_image(sample_list[1])
         seg_02 = interface.load_segmentation(sample_list[1])
-        self.assertTrue(np.array_equal(img_02[0], self.img[:, :, 0]))
+        true_img_02 = np.array(Image.fromarray(self.img[:, :, :3]).convert('LA'))
+        self.assertTrue(np.array_equal(img_02[0], true_img_02[:,:,0]))
         self.assertTrue(np.array_equal(seg_02, self.seg[:, :, 0]))
     # NIFTI_interface - Loading and Storage of Predictions
     def test_IOI_IMAGE_predictionhandling(self):


### PR DESCRIPTION
For some datasets like [Fluo-N2DL-HeLa](http://data.celltrackingchallenge.net/training-datasets/Fluo-N2DH-GOWT1.zip) after loading by `Image_interface` we get blank images because of `img_raw.convert("LA")` conversion. This breaks down training and execution of subfunctions. 